### PR TITLE
Add Go snippets directory and GetQueueAvailableAgents example

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ We currently have sippets in:
 * Java under [java/](java/README.md)
 * DotNet (C#) under [dotnet/](dotnet/README.md)
 * Javascript under [javascript/](javascript/README.md)
+* Go under [go/](go/README.md)
 
 Feel free to add more languages. Please follow the requirements in each subdirectory README.
 
@@ -18,6 +19,7 @@ Feel free to add more languages. Please follow the requirements in each subdirec
 | Outbound Dial | Uses the [StartOutboundVoiceContact](https://docs.aws.amazon.com/connect/latest/APIReference/API_StartOutboundVoiceContact.html) API to call a number. | [Java](java/OutboundExample) [DotNet](dotnet/OutboundExample) |
 | Holiday Check | Can be used to check for holidays in a contact flow | [Python](python/holidaycheck) |
 | Sync Instance User Data | Can be used to sync basic user information from one instance to another instance | [Python](python/syncinstances) |
+| Get Available Agents | Uses the [GetCurrentMetricData](https://docs.aws.amazon.com/connect/latest/APIReference/API_GetCurrentMetricData.html) API to get all available agents in a queue | [Go](go/GetQueueAvailableAgents) |
 
 ## Contributions
 

--- a/go/.gitignore
+++ b/go/.gitignore
@@ -1,0 +1,13 @@
+# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+main
+
+# Test binary, built with `go test -c`
+*.test
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out

--- a/go/GetQueueAvailableAgents/main.go
+++ b/go/GetQueueAvailableAgents/main.go
@@ -1,17 +1,3 @@
-/*
-   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-
-   This file is licensed under the Apache License, Version 2.0 (the "License").
-   You may not use this file except in compliance with the License. A copy of
-   the License is located at
-
-    http://aws.amazon.com/apache2.0/
-
-   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
-   CONDITIONS OF ANY KIND, either express or implied. See the License for the
-   specific language governing permissions and limitations under the License.
-*/
-
 package main
 
 import (

--- a/go/GetQueueAvailableAgents/main.go
+++ b/go/GetQueueAvailableAgents/main.go
@@ -1,0 +1,81 @@
+/*
+   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+   This file is licensed under the Apache License, Version 2.0 (the "License").
+   You may not use this file except in compliance with the License. A copy of
+   the License is located at
+
+    http://aws.amazon.com/apache2.0/
+
+   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+   specific language governing permissions and limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"flag"
+	"log"
+	"strings"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/connect"
+)
+
+func main() {
+	region := flag.String("r", "", "The AWS region where your Amazon Connect instance is in")
+	queue := flag.String("q", "", "The ARN of the Amazon Connect queue")
+	flag.Parse()
+
+	// Create a new AWS session for the configured region
+	sess := session.Must(session.NewSession())
+
+	// Use session to create Amazon Connect client for the configured region.
+	svc := connect.New(sess, &aws.Config{Region: region})
+
+	// Create the input for the the GetCurrentMetricData API.
+	// This will request a COUNT for the number of Agents available in the queue.
+	instance := strings.Join(strings.Split(aws.StringValue(queue), "/")[:2], "/") // instance ARN from queue ARN
+	input := &connect.GetCurrentMetricDataInput{
+		CurrentMetrics: []*connect.CurrentMetric{
+			{
+				Name: aws.String(connect.CurrentMetricNameAgentsAvailable),
+				Unit: aws.String(connect.UnitCount),
+			},
+		},
+		Filters: &connect.Filters{
+			Channels: []*string{aws.String(connect.ChannelVoice)},
+			Queues:   []*string{queue},
+		},
+		Groupings:  []*string{aws.String(connect.GroupingQueue)},
+		InstanceId: aws.String(instance),
+	}
+	if err := input.Validate(); err != nil {
+		log.Fatalf("Error validating GetCurrentMetricDataInput: %v", err)
+		return
+	}
+
+	// Create a pager. This will let us page over all of the metrics available
+	// when there are more metrics than can be returned in a single.
+	var count float64
+	pager := func(out *connect.GetCurrentMetricDataOutput, lastPage bool) bool {
+		for _, result := range out.MetricResults {
+			for _, collection := range result.Collections {
+				// If the metric returned is for the number of available agents, increment the counter
+				if aws.StringValue(collection.Metric.Name) == connect.CurrentMetricNameAgentsAvailable {
+					count += aws.Float64Value(collection.Value)
+				}
+			}
+		}
+		return lastPage
+	}
+	if err := svc.GetCurrentMetricDataPagesWithContext(context.Background(), input, pager); err != nil {
+		log.Fatalf("Error calling GetCurrentMetricDataPagesWithContext: %v", err)
+		return
+	}
+	// Use a default context, the input, and the pager to call the GetCurrentMetricData API.
+	log.Printf("There are %d available agents in the queue.", int(count))
+}

--- a/go/README.md
+++ b/go/README.md
@@ -1,9 +1,9 @@
 # Amazon Connect Snippets in Go
 These programs demonstrate various use cases that interact with Amazon Connect using the AWS SDK for Go.
 
-These examples use Go 1.14 and [Go modules](https://github.com/golang/go/wiki/Modules) to manage the dependency on the AWS SDK for Go.
+These examples use [Go modules](https://github.com/golang/go/wiki/Modules) to manage the dependency on the AWS SDK for Go.
 
-1. [GetQueueAvailableAgents](./GetQueueAvailableAgents): Returns all of the agents that are in the Available state in a certain call queue. Uses the [GetCurrentMetricDataOutput API](https://docs.aws.amazon.com/sdk-for-go/api/service/connect/#Connect.GetCurrentMetricData).
+1. [GetQueueAvailableAgents](./GetQueueAvailableAgents): Returns all of the agents that are in the Available state in a certain call queue. Uses the [GetCurrentMetricData API](https://docs.aws.amazon.com/sdk-for-go/api/service/connect/#Connect.GetCurrentMetricData).
     ```bash
     go run ./GetQueueAvailableAgents/main.go -r <aws-region> -q <queue-arn>
     ```

--- a/go/README.md
+++ b/go/README.md
@@ -1,0 +1,10 @@
+# Amazon Connect Snippets in Go
+These programs demonstrate various use cases that interact with Amazon Connect using the AWS SDK for Go.
+
+These examples use Go 1.14 and [Go modules](https://github.com/golang/go/wiki/Modules) to manage the dependency on the AWS SDK for Go.
+
+1. [GetQueueAvailableAgents](./GetQueueAvailableAgents): Returns all of the agents that are in the Available state in a certain call queue. Uses the [GetCurrentMetricDataOutput API](https://docs.aws.amazon.com/sdk-for-go/api/service/connect/#Connect.GetCurrentMetricData).
+    ```bash
+    go run ./GetQueueAvailableAgents/main.go -r <aws-region> -q <queue-arn>
+    ```
+    Example output: `There are 8 available agents in the queue.`

--- a/go/go.mod
+++ b/go/go.mod
@@ -1,0 +1,5 @@
+module github.com/amazon-connect/amazon-connect-samples/amazon-connect-snippets/go
+
+go 1.14
+
+require github.com/aws/aws-sdk-go v1.30.9

--- a/go/go.sum
+++ b/go/go.sum
@@ -1,0 +1,16 @@
+github.com/aws/aws-sdk-go v1.30.9 h1:DntpBUKkchINPDbhEzDRin1eEn1TG9TZFlzWPf0i8to=
+github.com/aws/aws-sdk-go v1.30.9/go.mod h1:5zCpMtNQVjRREroY7sYe8lOMRSxkhG6MZveU8YkpAk0=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/go-sql-driver/mysql v1.5.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
+github.com/jmespath/go-jmespath v0.3.0 h1:OS12ieG61fsCg5+qLJ+SsW9NicxNkg3b25OyT2yCeUc=
+github.com/jmespath/go-jmespath v0.3.0/go.mod h1:9QtRXoHjLGCJ5IBSaohpXITPlowMeeYCZ7fLUTSywik=
+github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
+golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
+golang.org/x/net v0.0.0-20200202094626-16171245cfb2/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Adds Go directory for snippets and example which returns the number of available agents in a queue

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
